### PR TITLE
Fix Timestamp JSON Marshaler

### DIFF
--- a/tests.go
+++ b/tests.go
@@ -292,8 +292,8 @@ func (tp *TestParams) getQueryString() string {
 
 type Timestamp time.Time
 
-func (t *Timestamp) MarshalJSON() ([]byte, error) {
-	ts := time.Time(*t).Unix()
+func (t Timestamp) MarshalJSON() ([]byte, error) {
+	ts := time.Time(t).Unix()
 	stamp := fmt.Sprint(ts)
 	return []byte(stamp), nil
 }


### PR DESCRIPTION
The json.Marshaler interface is not currently satisfied, and requires a non-pointer receiver to satisfy the interface.

https://groups.google.com/forum/#!topic/golang-nuts/gW53LC_ZC98